### PR TITLE
feat: implement match system with create, fetch and display

### DIFF
--- a/frontend/src/components/CreateMatchForm/CreateMatchForm.tsx
+++ b/frontend/src/components/CreateMatchForm/CreateMatchForm.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react'
+import { toast } from 'react-toastify';
+import { MESSAGES } from '../../utils/messages';
+import AddButton from '../AddButton/AddButton';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Controller, useForm } from 'react-hook-form';
+import { FormControl, FormHelperText, InputLabel, Select, MenuItem, FilledInput } from '@mui/material';
+import { createMatchSchema } from '../../utils/createMatchSchema';
+import { Lobby, LobbyMatchData } from '../../pages/Dashboard/types/lobby.types';
+import { createMatch } from '../../services/lobbies/createMatch';
+import { useGroupMembers } from '../../hooks/useGroupMembers';
+
+type CreateMatchFormData = {
+    firstUserId: string,
+    secondUserId: string,
+    firstUserScore: number,
+    secondUserScore: number,
+}
+
+const CreateMatchForm: React.FC<{ onSuccess: () => Promise<void>, lobbyData: Lobby }> = ({ onSuccess, lobbyData }) => {
+    const { groupMembers } = useGroupMembers(lobbyData.group_id);
+    const { id } = lobbyData;
+    const match: CreateMatchFormData = {
+        firstUserId: '',
+        secondUserId: '',
+        firstUserScore: 0,
+        secondUserScore: 0,
+    };
+    const { register, handleSubmit, formState: { errors }, reset, control } = useForm({
+        defaultValues: match,
+        resolver: yupResolver<CreateMatchFormData>(createMatchSchema),
+    });
+    const [isClicked, setIsClicked] = useState<boolean>(false);
+    const showForm = () => {
+        setIsClicked(true);
+        reset();
+    }
+    const closeForm = () => {
+        setIsClicked(false);
+    };
+    const submitMatchData = async (match: CreateMatchFormData) => {
+        const participants = [
+            { user_id: match.firstUserId, score: match.firstUserScore },
+            { user_id: match.secondUserId, score: match.secondUserScore }
+        ];
+        const createMatchFormDataPlusLobbyId: LobbyMatchData = {
+            lobby_id: id,
+            participants
+        };
+
+        try {
+            await createMatch(createMatchFormDataPlusLobbyId);
+            closeForm();
+            await onSuccess();
+            toast.success(MESSAGES.SUCCESS.CREATED_MATCH)
+        } catch (error: unknown) {
+            if (error instanceof Error) {
+                toast.error(error.message);
+            } else {
+                toast.error(MESSAGES.ERROR.UNKNOWN);
+            }
+        };
+    };
+    return <>
+        {isClicked && (
+            <form className='top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 p-6 bg-slate-500 flex flex-col fixed shadow-xl rounded-2xl'
+                onSubmit={handleSubmit(submitMatchData)} >
+                <FormControl>
+                    <InputLabel id='first-username-select-label'>
+                        first username
+                    </InputLabel>
+                    <Controller
+                        name='firstUserId'
+                        control={control}
+                        render={({ field }) => (
+                            <Select {...field} placeholder='Username'>{groupMembers.map((member) => {
+                                return (
+                                    <MenuItem key={member.id} value={member.id}>{member.username}</MenuItem>
+                                )
+                            })}</Select>
+                        )} />
+                    {errors.firstUserId && <FormHelperText>{errors.firstUserId?.message}</FormHelperText>}
+                </FormControl>
+                <FormControl>
+                    <InputLabel htmlFor={'firstUserScore'}>
+                        Score
+                    </InputLabel>
+                    <FilledInput
+                        type='number'
+                        placeholder='Score'
+                        {...register('firstUserScore')} />
+                    {errors.firstUserScore && <FormHelperText>{errors.firstUserScore?.message}</FormHelperText>}
+                </FormControl>
+                <FormControl>
+                    <InputLabel htmlFor={'secondUserScore'}>
+                        Score
+                    </InputLabel>
+                    <FilledInput
+                        type='number'
+                        placeholder='Score'
+                        {...register('secondUserScore')} />
+                    {errors.secondUserScore && <FormHelperText>{errors.secondUserScore?.message}</FormHelperText>}
+                </FormControl>
+                <FormControl>
+                    <InputLabel id='second-username-select-label'>
+                        second username
+                    </InputLabel>
+                    <Controller
+                        name='secondUserId'
+                        control={control}
+                        render={({ field }) => (
+                            <Select {...field} placeholder='Username'>{groupMembers.map((member) => {
+                                return (
+                                    <MenuItem key={member.id} value={member.id}>{member.username}</MenuItem>
+                                )
+                            })}
+                            </Select>
+                        )} />
+                    {errors.secondUserId && <FormHelperText>{errors.secondUserId?.message}</FormHelperText>}
+                </FormControl>
+                <button type='button' onClick={closeForm}>X</button>
+                <button type='submit'>dodaj</button>
+            </form>
+        )}
+        <div style={{ background: 'none', border: 'none' }} onClick={showForm}>
+            <AddButton />
+        </div>
+    </>
+};
+
+export default CreateMatchForm;

--- a/frontend/src/components/GroupItem/GroupItem.tsx
+++ b/frontend/src/components/GroupItem/GroupItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { UserGroup } from '../../pages/Dashboard/types/group.types';
 import UpdateGroupForm from '../UpdateGroup/UpdateGroupForm';
 import CreateLobbyForm from '../CreateLobby/CreateLobbyForm';
@@ -12,7 +12,6 @@ import GroupMembers from '../GroupMembers/GroupMembers';
 import { leaveGroup } from '../../services/leaveGroup';
 
 const GroupItem: React.FC<{ groupData: UserGroup, refetchGroups: () => Promise<void> }> = ({ groupData, refetchGroups }) => {
-
   const { id, name, description, role, invite_code } = groupData;
   const { lobbies, refetchLobbies } = useGroupLobbies(id);
 
@@ -69,7 +68,7 @@ const GroupItem: React.FC<{ groupData: UserGroup, refetchGroups: () => Promise<v
         <button onClick={() => handleLeaveGroup(id)}>leave</button>
       )}
       <Lobbies lobbies={lobbies} />
-    </li >
+    </li>
   )
 }
 

--- a/frontend/src/components/Lobbies/Lobbies.tsx
+++ b/frontend/src/components/Lobbies/Lobbies.tsx
@@ -4,6 +4,7 @@ import { joinLobby } from '../../services/lobbies/joinLobby';
 import { toast } from 'react-toastify';
 import { MESSAGES } from '../../utils/messages';
 import { useAuth } from '../../features/useAuth';
+import LobbyItem from '../LobbyItem/LobbyItem';
 
 const Lobbies: React.FC<{ lobbies: Lobby[] }> = ({ lobbies }) => {
     const { user } = useAuth();
@@ -29,16 +30,14 @@ const Lobbies: React.FC<{ lobbies: Lobby[] }> = ({ lobbies }) => {
         <div>
             <h3>Lobbies:</h3>
             <ul>
-                {
-                    lobbies.map((lobby: Lobby) => {
-                        return (
-                            <li key={lobby.id}><button onClick={() => handleJoinLobby(lobby)}>join lobby</button>{lobby.game_type}</li>
-                        )
-                    })
-                }
+                {lobbies.map((lobby: Lobby) => {
+                    return (
+                        <LobbyItem key={lobby.id} handleJoinLobby={handleJoinLobby} lobbyData={lobby} />
+                    )
+                })}
             </ul>
         </div>
-    );
-};
+    )
+}
 
 export default Lobbies;

--- a/frontend/src/components/LobbyItem/LobbyItem.tsx
+++ b/frontend/src/components/LobbyItem/LobbyItem.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Lobby } from '../../pages/Dashboard/types/lobby.types';
+import { useLobbyMatches } from '../../hooks/useLobbiesMatches';
+import CreateMatchForm from '../CreateMatchForm/CreateMatchForm';
+
+type LobbyItemProps = {
+    handleJoinLobby: (lobby: Lobby) => Promise<void>;
+    lobbyData: Lobby;
+}
+
+const LobbyItem: React.FC<LobbyItemProps> = ({ handleJoinLobby, lobbyData }) => {
+    const lobbyId = lobbyData.id;
+    const { matches, loading, error, refetch } = useLobbyMatches(lobbyId);
+
+    return (
+        <li>
+            <CreateMatchForm onSuccess={refetch} lobbyData={lobbyData} />
+            <button onClick={() => handleJoinLobby(lobbyData)}>join lobby</button>
+            <h4>{lobbyData.game_type}</h4>
+            <h4>Matches:</h4>
+            {error
+                ? <p>{error}</p>
+                : loading
+                    ? <p>Loading...</p>
+                    : matches.length === 0
+                        ? <p>Brak meczów</p>
+                        : (matches.map((match) => {
+                            return (
+                                <div key={match.matchId}>
+                                    {match.players.map((p) => {
+                                        return (
+                                            <div key={p.userId}>
+                                                <p>{p.username}: {p.score}</p>
+                                            </div>
+                                        )
+                                    })}
+                                </div>
+                            )
+                        }))
+            }
+        </li>
+    )
+};
+
+export default LobbyItem;

--- a/frontend/src/hooks/useLobbiesMatches.ts
+++ b/frontend/src/hooks/useLobbiesMatches.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { getLobbyMatches } from "../services/lobbies/lobbyMatchesService";
+import { Match } from "../pages/Dashboard/types/lobby.types";
+
+export function useLobbyMatches(lobbyId: string) {
+    const [matches, setMatches] = useState<Match[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadMatches = async function (): Promise<void> {
+        setError(null);
+        setLoading(true);
+
+        try {
+            const data = await getLobbyMatches(lobbyId);
+            setMatches(data || []);
+        } catch (error) {
+            if (error instanceof Error) {
+                setError(error.message);
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!lobbyId) {
+            setLoading(false);
+            return;
+        }
+        setMatches([]);
+        loadMatches();
+    }, [lobbyId]);
+
+    return {
+        matches,
+        error,
+        loading,
+        refetch: loadMatches,
+    };
+};

--- a/frontend/src/pages/Dashboard/types/lobby.types.ts
+++ b/frontend/src/pages/Dashboard/types/lobby.types.ts
@@ -8,3 +8,20 @@ export type LobbyMember = {
     lobby_id: string;
     user_id: string;
 };
+
+export type LobbyMatchData = {
+    lobby_id: string,
+    participants: {
+        user_id: string,
+        score: number,
+    }[],
+};
+
+export type Match = {
+    matchId: string,
+    players: {
+        userId: string,
+        username: string,
+        score: number,
+    }[],
+}

--- a/frontend/src/services/lobbies/createMatch.ts
+++ b/frontend/src/services/lobbies/createMatch.ts
@@ -1,0 +1,13 @@
+import { supabase } from "../../shared/api/supabaseClient";
+import { LobbyMatchData } from "../../pages/Dashboard/types/lobby.types";
+
+export async function createMatch(createLobbyMatchData: LobbyMatchData): Promise<string> {
+    const { lobby_id, participants } = createLobbyMatchData;
+
+    const { data, error } = await supabase.rpc('create_match_with_scores', {
+        input_lobby_id: lobby_id,
+        input_participants: participants,
+    });
+    if (error) throw error;
+    return data;
+};

--- a/frontend/src/services/lobbies/lobbyMatchesService.ts
+++ b/frontend/src/services/lobbies/lobbyMatchesService.ts
@@ -1,0 +1,49 @@
+import { supabase } from "../../shared/api/supabaseClient";
+import { Match } from "../../pages/Dashboard/types/lobby.types";
+
+export async function getLobbyMatches(lobbyId: string) {
+    const { data, error } = await supabase
+        .from('matches')
+        .select(`
+            id,
+            match_participants (
+                user_id,
+                profiles (username)
+            ),
+            match_scores (
+                user_id,
+                score
+            )
+            `)
+        .eq('lobby_id', lobbyId);
+
+    if (error) throw error;
+
+    const mapped: Match[] = data?.map((match) => {
+        const scores = match.match_scores;
+        const participants = match.match_participants;
+
+        const players = participants.map(p => {
+            if (!p.user_id) throw new Error('Missing user_id')
+
+            const profile = Array.isArray(p.profiles)
+                ? p.profiles[0]
+                : p.profiles;
+
+            const score = scores.find(s => s.user_id === p.user_id);
+
+            return {
+                userId: p.user_id,
+                username: profile?.username ?? 'unknown',
+                score: score?.score ?? 0
+            }
+        });
+
+        return {
+            matchId: match.id,
+            players,
+        };
+    }) || [];
+
+    return mapped;
+};

--- a/frontend/src/utils/createMatchSchema.ts
+++ b/frontend/src/utils/createMatchSchema.ts
@@ -1,0 +1,28 @@
+import * as Yup from 'yup';
+import { MESSAGES } from './messages';
+
+export const createMatchSchema = Yup.object({
+    firstUserId: Yup
+        .string()
+        .required(MESSAGES.ERROR.REQUIRED),
+    secondUserId: Yup
+        .string()
+        .required(MESSAGES.ERROR.REQUIRED)
+        .test(
+            'not-same-user-id',
+            'Nie możesz wybrać tego samego użytkownika',
+            function (value) {
+                const { firstUserId } = this.parent;
+
+                if (!value || !firstUserId) return true;
+
+                return firstUserId !== value;
+            }
+        ),
+    firstUserScore: Yup
+        .number()
+        .required(MESSAGES.ERROR.REQUIRED),
+    secondUserScore: Yup
+        .number()
+        .required(MESSAGES.ERROR.REQUIRED),
+});

--- a/frontend/src/utils/messages.ts
+++ b/frontend/src/utils/messages.ts
@@ -9,6 +9,7 @@ export const MESSAGES = {
         JOINED_LOBBY: 'Dołączyłeś do lobby!',
         JOINED_GROUP: 'Dołączyłeś do grupy!',
         LEFT_GROUP: 'Opuściłeś grupę.',
+        CREATED_MATCH: 'Utworzyłeś mecz!',
     },
     ERROR: {
         REQUIRED: 'To pole jest wymagane.',


### PR DESCRIPTION
This PR introduces a complete match system for lobbies.
Users can create matches between two participants, assign scores, and view match history directly within a lobby.

- Added match creation via RPC (create_match_with_scores)
- Implemented createMatch service for frontend integration
- Created useLobbyMatches hook for fetching and transforming match data
- Added match list UI 
- Implemented match creation form with validation (Yup + react-hook-form)

TODO: 
- Support for more than 2 participants
- Leaderboard based on aggregated scores
- Improved UX 
